### PR TITLE
Add table of contents navigation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ recall -q "database schema migration" --agent atlas --days 2
 
 Claw Recall indexes all your agent conversations into a searchable SQLite database with full-text and semantic search. It also captures Gmail, Google Drive, and Slack — giving every agent access to a shared memory that survives compaction, restarts, and context limits.
 
+**[Quick Start](#quick-start)** | **[MCP Tools](#mcp-tools)** | **[CLI](#cli-reference)** | **[REST API](#rest-api)** | **[Data Ingestion](#data-ingestion)** | **[Search Modes](#search-modes)** | **[Configuration](#configuration)** | **[Production Deployment](#production-deployment)** | **[Testing](#testing)**
+
 [Changelog](CHANGELOG.md) | [Discord](https://discord.gg/4wGTVa9Bt6) | [Contributing](CONTRIBUTING.md)
 
 ---


### PR DESCRIPTION
## Summary

- Add a section navigation bar at the top of the README linking to all major sections
- Readers can now jump directly to Quick Start, MCP Tools, CLI, REST API, Data Ingestion, Search Modes, Configuration, Production Deployment, and Testing

## Test plan

- [ ] Verify all anchor links work on GitHub
- [ ] Check rendering on GitHub

Generated with [Claude Code](https://claude.com/claude-code)