### PR TITLE
Fix resource leaks in watcher and session pusher

### DIFF
--- a/cc-session-watcher.py
+++ b/cc-session-watcher.py
@@ -286,34 +286,34 @@ def push_file(filepath: Path, dry_run: bool = False) -> dict:
         log.info(f"[DRY RUN] Would push: {filepath} ({file_size:,} bytes)")
         return {"status": "dry_run"}
 
-    session = requests.Session()
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            with open(filepath, 'rb') as f:
-                response = session.post(
-                    VPS_ENDPOINT,
-                    files={'file': (filepath.name, f, 'application/x-jsonlines')},
-                    data={'source_path': str(filepath)},
-                    timeout=300,
-                )
+    with requests.Session() as session:
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                with open(filepath, 'rb') as f:
+                    response = session.post(
+                        VPS_ENDPOINT,
+                        files={'file': (filepath.name, f, 'application/x-jsonlines')},
+                        data={'source_path': str(filepath)},
+                        timeout=300,
+                    )
 
-            if response.status_code == 200:
-                result = response.json()
-                return result
-            else:
-                log.warning(f"Push failed ({response.status_code}): {response.text[:200]}")
+                if response.status_code == 200:
+                    result = response.json()
+                    return result
+                else:
+                    log.warning(f"Push failed ({response.status_code}): {response.text[:200]}")
 
-        except requests.ConnectionError:
-            log.warning(f"VPS unreachable (attempt {attempt}/{MAX_RETRIES})")
-        except requests.Timeout:
-            log.warning(f"Push timed out (attempt {attempt}/{MAX_RETRIES})")
-        except Exception as e:
-            log.error(f"Push error: {e}")
+            except requests.ConnectionError:
+                log.warning(f"VPS unreachable (attempt {attempt}/{MAX_RETRIES})")
+            except requests.Timeout:
+                log.warning(f"Push timed out (attempt {attempt}/{MAX_RETRIES})")
+            except Exception as e:
+                log.error(f"Push error: {e}")
 
-        if attempt < MAX_RETRIES:
-            delay = RETRY_BASE_DELAY * attempt
-            log.info(f"Retrying in {delay}s...")
-            time.sleep(delay)
+            if attempt < MAX_RETRIES:
+                delay = RETRY_BASE_DELAY * attempt
+                log.info(f"Retrying in {delay}s...")
+                time.sleep(delay)
 
     return {"status": "error", "reason": "max_retries_exceeded"}
 

--- a/watcher.py
+++ b/watcher.py
@@ -57,6 +57,15 @@ class IndexWorker(threading.Thread):
         self._conn = None
         self.stats = {"indexed": 0, "skipped": 0, "errors": 0, "retries": 0}
 
+    def close(self):
+        """Close the persistent DB connection (call from main thread on shutdown)."""
+        if self._conn:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            self._conn = None
+
     def _get_conn(self):
         if self._conn is None:
             self._conn = sqlite3.connect(str(DB_PATH), timeout=BUSY_TIMEOUT_MS / 1000)
@@ -175,6 +184,7 @@ def main():
             log.info(f"Stats: indexed={s['indexed']} skipped={s['skipped']} retries={s['retries']} errors={s['errors']}")
     except KeyboardInterrupt:
         observer.stop()
+        worker.close()
         log.info(f"Watcher stopped. Stats: {worker.stats}")
 
     observer.join()


### PR DESCRIPTION
## Summary

- **cc-session-watcher.py**: Wrap `requests.Session()` in context manager to properly close TCP connections after each push. Previously leaked sockets over long-running sessions.
- **watcher.py**: Add `close()` method to `IndexWorker` and call it on shutdown to properly close the DB connection and checkpoint the WAL file.

## Test plan

- [x] All 123 existing tests pass
- [ ] Verify watcher restarts cleanly: `sudo systemctl restart claw-recall-watcher && sleep 2 && sudo systemctl status claw-recall-watcher`

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)