### PR TITLE
Improve error handling and logging

### DIFF
--- a/recall.py
+++ b/recall.py
@@ -231,7 +231,7 @@ def unified_search(
                     "channel": r.channel,
                     "role": r.role,
                     "content": r.content[:500],
-                    "fullContent": r.content[:500],
+                    "fullContent": r.content,
                     "timestamp": r.timestamp.isoformat() if r.timestamp else None,
                     "score": round(r.score, 3),
                     "session_id": r.session_id,

--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -72,6 +72,7 @@ def main():
         print(f"Embedding {len(rows)} / {gap} remaining messages...")
 
     embedded = 0
+    errors = 0
     for i in range(0, len(rows), EMBEDDING_BATCH_SIZE):
         batch = rows[i:i + EMBEDDING_BATCH_SIZE]
         texts = [content[:2000] for _, content in batch]
@@ -86,8 +87,10 @@ def main():
                 )
                 embedded += 1
         except Exception as e:
+            errors += 1
             if not args.quiet:
-                print(f"Batch error: {e}")
+                print(f"Batch error at offset {i}: {e}")
+            conn.commit()  # Save progress before stopping
             break
 
         if (i + EMBEDDING_BATCH_SIZE) % 200 == 0:
@@ -97,7 +100,11 @@ def main():
     conn.close()
 
     if not args.quiet:
-        print(f"Done: {embedded} embedded, {gap - embedded} remaining")
+        print(f"Done: {embedded} embedded, {gap - embedded} remaining" +
+              (f", {errors} batch errors" if errors else ""))
+
+    if errors:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/search_files.py
+++ b/search_files.py
@@ -5,6 +5,7 @@ Complements convo-memory by searching persistent docs, not just conversations.
 """
 
 import argparse
+import logging
 import os
 import re
 from pathlib import Path
@@ -59,7 +60,8 @@ def _get_file_lines(filepath: Path) -> List[str]:
             _file_cache.pop(next(iter(_file_cache)))
         _file_cache[path_str] = (mtime, lines)
         return lines
-    except Exception:
+    except Exception as e:
+        logging.getLogger("search_files").warning(f"Could not read {filepath}: {e}")
         return []
 
 

--- a/web.py
+++ b/web.py
@@ -93,7 +93,8 @@ def status_endpoint():
             try:
                 info["db_thoughts"] = conn.execute("SELECT COUNT(*) FROM thoughts").fetchone()[0]
                 info["db_thought_embeddings"] = conn.execute("SELECT COUNT(*) FROM thought_embeddings").fetchone()[0]
-            except Exception:
+            except Exception as e:
+                log.debug(f"Thought tables not available: {e}")
                 info["db_thoughts"] = 0
     except Exception as e:
         info["db_error"] = str(e)


### PR DESCRIPTION
## Summary

- **search_files.py**: Log file read errors instead of silently returning empty results
- **web.py**: Log exceptions when thought tables aren't available in `/status`
- **recall.py**: Return full content in `fullContent` field (was truncated to 500 chars same as `content`, making the field name misleading)
- **backfill_embeddings.py**: Commit progress before stopping on batch error, report error count in output, exit with code 1 so cron jobs can detect failures

## Test plan

- [x] All 123 existing tests pass
- [ ] Verify `/status` endpoint still works: `curl -s http://localhost:8765/status | jq .db_thoughts`
- [ ] Run backfill with bad API key to verify exit code 1

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)