### PR TITLE
Add configurable session exclusion via exclude.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ htmlcov/
 # Environment & config
 .env
 agents.json
+exclude.conf
 
 # Logs & temp
 *.log

--- a/cleanup_excluded.py
+++ b/cleanup_excluded.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Claw Recall — Cleanup Excluded Sessions
+
+Reads exclude.conf and removes any already-indexed sessions whose source
+filename matches an exclusion pattern. Run after updating exclude.conf to
+purge historical noise from the database.
+
+Usage:
+    python3 cleanup_excluded.py              # Delete matching sessions
+    python3 cleanup_excluded.py --dry-run    # Preview what would be deleted
+"""
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from index import DB_PATH, is_excluded, _load_exclude_patterns
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Remove excluded sessions from Claw Recall database")
+    parser.add_argument('--dry-run', action='store_true', help="Preview deletions without modifying the database")
+    parser.add_argument('--db', type=str, default=None, help="Path to database (default: auto-detect)")
+    args = parser.parse_args()
+
+    db_path = Path(args.db) if args.db else DB_PATH
+    if not db_path.exists():
+        print(f"Database not found: {db_path}")
+        sys.exit(1)
+
+    patterns = _load_exclude_patterns()
+    if not patterns:
+        print("No exclusion patterns found. Copy exclude.conf.example to exclude.conf and customize it.")
+        sys.exit(0)
+
+    print(f"Exclusion patterns: {patterns}")
+    print(f"Database: {db_path}")
+    print()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    # Find all sessions whose source file matches an exclusion pattern
+    rows = conn.execute(
+        "SELECT id, agent_id, source_file, message_count FROM sessions"
+    ).fetchall()
+
+    to_delete = []
+    for session_id, agent_id, source_file, msg_count in rows:
+        if source_file and is_excluded(Path(source_file)):
+            to_delete.append((session_id, agent_id, source_file, msg_count))
+
+    if not to_delete:
+        print("No matching sessions found. Database is clean.")
+        conn.close()
+        return
+
+    print(f"Found {len(to_delete)} sessions to remove:\n")
+    total_messages = 0
+    for session_id, agent_id, source_file, msg_count in to_delete:
+        fname = Path(source_file).name if source_file else session_id
+        total_messages += msg_count or 0
+        print(f"  [{agent_id:>10}]  {fname}  ({msg_count or 0} msgs)")
+
+    print(f"\nTotal: {len(to_delete)} sessions, {total_messages} messages")
+
+    if args.dry_run:
+        print("\n--dry-run: No changes made.")
+        conn.close()
+        return
+
+    # Delete in order: embeddings -> messages -> index_log -> sessions
+    session_ids = [s[0] for s in to_delete]
+    placeholders = ','.join(['?'] * len(session_ids))
+
+    embed_count = conn.execute(
+        f"DELETE FROM embeddings WHERE message_id IN (SELECT id FROM messages WHERE session_id IN ({placeholders}))",
+        session_ids
+    ).rowcount
+
+    msg_count = conn.execute(
+        f"DELETE FROM messages WHERE session_id IN ({placeholders})",
+        session_ids
+    ).rowcount
+
+    # Clean up index_log by source_file
+    source_files = [s[2] for s in to_delete if s[2]]
+    if source_files:
+        sf_placeholders = ','.join(['?'] * len(source_files))
+        conn.execute(
+            f"DELETE FROM index_log WHERE source_file IN ({sf_placeholders})",
+            source_files
+        )
+
+    conn.execute(
+        f"DELETE FROM sessions WHERE id IN ({placeholders})",
+        session_ids
+    )
+
+    conn.commit()
+    conn.close()
+
+    print(f"\nDeleted: {len(session_ids)} sessions, {msg_count} messages, {embed_count} embeddings")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/exclude.conf.example
+++ b/exclude.conf.example
@@ -1,0 +1,23 @@
+# Claw Recall — Exclusion Patterns
+#
+# Copy this file to 'exclude.conf' and customize for your installation.
+# Files matching these patterns are skipped during indexing.
+#
+# Format:
+#   - One filename glob pattern per line
+#   - Patterns are matched against the filename only (not the full path)
+#   - Standard glob syntax: * matches anything, ? matches one character
+#   - Lines starting with # are comments
+#   - Blank lines are ignored
+#
+# After updating this file, run the cleanup script to remove
+# already-indexed sessions that match the new patterns:
+#
+#   python3 cleanup_excluded.py [--dry-run]
+
+# OpenClaw boot check sessions (system noise, not real conversations)
+boot-*.jsonl
+
+# Compaction artifacts
+acompact-*.jsonl
+compact-*.jsonl

--- a/index.py
+++ b/index.py
@@ -25,11 +25,38 @@ except ImportError:
 DB_PATH = Path(__file__).parent / "convo_memory.db"
 DEFAULT_ARCHIVE_PATH = Path.home() / ".openclaw" / "agents-archive"
 DEFAULT_SESSIONS_PATH = Path.home() / ".openclaw" / "agents"
+EXCLUDE_CONF_PATH = Path(__file__).parent / "exclude.conf"
 
 # Embedding settings
 EMBEDDING_MODEL = "text-embedding-3-small"
 EMBEDDING_BATCH_SIZE = 20  # Keep small to stay within 8192 token limit per API call
 MIN_CONTENT_LENGTH = 20  # Skip very short messages for embeddings
+
+# --- Exclusion patterns (loaded from exclude.conf if present) ---
+import fnmatch as _fnmatch
+
+_exclude_patterns: list[str] | None = None
+
+def _load_exclude_patterns() -> list[str]:
+    """Load filename glob patterns from exclude.conf (one per line, # comments)."""
+    global _exclude_patterns
+    if _exclude_patterns is not None:
+        return _exclude_patterns
+    _exclude_patterns = []
+    if EXCLUDE_CONF_PATH.exists():
+        for line in EXCLUDE_CONF_PATH.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith('#'):
+                _exclude_patterns.append(line)
+    return _exclude_patterns
+
+def is_excluded(filepath: Path) -> bool:
+    """Check if a file should be excluded from indexing based on exclude.conf patterns."""
+    name = filepath.name
+    for pattern in _load_exclude_patterns():
+        if _fnmatch.fnmatch(name, pattern):
+            return True
+    return False
 
 
 def parse_session_file(filepath: Path) -> Generator[dict, None, None]:
@@ -436,6 +463,8 @@ def index_session_file(
             Used by the /index-session endpoint for remote files.
     """
     _ensure_incremental_schema(conn)
+    if is_excluded(filepath):
+        return {'status': 'skipped', 'reason': 'excluded by exclude.conf'}
     canonical_source = source_file_override or str(filepath)
     current_size = filepath.stat().st_size
 

--- a/watcher.py
+++ b/watcher.py
@@ -25,7 +25,7 @@ from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
 sys.path.insert(0, str(Path(__file__).parent))
-from index import index_session_file, DB_PATH
+from index import index_session_file, DB_PATH, is_excluded
 
 # Directories to watch
 WATCH_DIRS = [
@@ -129,7 +129,8 @@ class SessionFileHandler(FileSystemEventHandler):
     def _should_handle(self, path: str) -> bool:
         return (path.endswith('.jsonl')
                 and '/subagents/' not in path
-                and '.deleted.' not in path)
+                and '.deleted.' not in path
+                and not is_excluded(Path(path)))
 
     def on_created(self, event):
         if not event.is_directory and self._should_handle(event.src_path):

--- a/web.py
+++ b/web.py
@@ -24,6 +24,7 @@ VALID_AGENT_FILTER = """
     AND s.agent_id NOT LIKE 'agent:%'
     AND s.agent_id NOT GLOB '[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]*'
     AND s.agent_id NOT IN ('boot', 'acompact', 'compact')
+    AND s.id NOT LIKE 'boot-%'
 """
 
 
@@ -136,7 +137,7 @@ def agents_endpoint():
             """
             params = []
             if days > 0:
-                sql += " AND s.started_at >= datetime('now', ?)"
+                sql += " AND COALESCE(s.ended_at, s.started_at) >= datetime('now', ?)"
                 params.append(f"-{days} days")
             sql += " GROUP BY norm_agent ORDER BY cnt DESC"
             rows = conn.execute(sql, params).fetchall()
@@ -465,7 +466,7 @@ def activity_endpoint():
             conn.row_factory = sqlite3.Row
 
             sql = f"""
-                SELECT s.id, s.agent_id, s.started_at, s.message_count,
+                SELECT s.id, s.agent_id, s.started_at, s.ended_at, s.message_count,
                        (SELECT content FROM messages m WHERE m.session_id = s.id AND m.role = 'user' ORDER BY m.message_index ASC LIMIT 1) as first_user_msg,
                        (SELECT content FROM messages m WHERE m.session_id = s.id AND m.role = 'assistant' ORDER BY m.message_index DESC LIMIT 1) as last_assistant_msg
                 FROM sessions s
@@ -476,9 +477,9 @@ def activity_endpoint():
                 sql += " AND s.agent_id = ? COLLATE NOCASE"
                 params.append(agent)
             if days > 0:
-                sql += " AND s.started_at >= datetime('now', ?)"
+                sql += " AND COALESCE(s.ended_at, s.started_at) >= datetime('now', ?)"
                 params.append(f"-{days} days")
-            sql += " ORDER BY s.started_at DESC LIMIT ?"
+            sql += " ORDER BY COALESCE(s.ended_at, s.started_at) DESC LIMIT ?"
             params.append(limit)
 
             rows = conn.execute(sql, params).fetchall()
@@ -491,6 +492,7 @@ def activity_endpoint():
                     "session_id": r['id'],
                     "agent": r['agent_id'],
                     "started_at": r['started_at'],
+                    "ended_at": r['ended_at'],
                     "message_count": r['message_count'],
                     "first_user_message": first_msg,
                     "last_assistant_message": last_msg,
@@ -503,7 +505,7 @@ def activity_endpoint():
             """
             count_params = []
             if days > 0:
-                count_sql += " AND s.started_at >= datetime('now', ?)"
+                count_sql += " AND COALESCE(s.ended_at, s.started_at) >= datetime('now', ?)"
                 count_params.append(f"-{days} days")
             count_sql += " GROUP BY s.agent_id ORDER BY cnt DESC"
             agent_counts = {r[0]: r[1] for r in conn.execute(count_sql, count_params).fetchall()}


### PR DESCRIPTION
## Summary

- **Configurable exclusion**: Add `exclude.conf` support — filename glob patterns that are skipped during indexing. The file is gitignored so each installation can customize without affecting the repo.
- **`exclude.conf.example`** ships with sensible defaults: `boot-*.jsonl` (OpenClaw boot check noise), `acompact-*.jsonl`, `compact-*.jsonl`
- **Cleanup script** (`cleanup_excluded.py`): Reads `exclude.conf` and purges matching sessions already in the DB. Supports `--dry-run` to preview before deleting.
- **Activity sort fix**: Browse/activity endpoints now sort and filter by `ended_at` (last message time) instead of `started_at`, so long-running sessions with recent activity appear when filtering by "Today"
- **Boot session filter**: Added `AND s.id NOT LIKE 'boot-%'` to `VALID_AGENT_FILTER` as a safety net in the web UI

## Usage

```bash
# Copy and customize the exclusion config
cp exclude.conf.example exclude.conf

# Preview what would be cleaned up
python3 cleanup_excluded.py --dry-run

# Remove matching sessions from the database
python3 cleanup_excluded.py
```

## Test plan

- [x] `cleanup_excluded.py --dry-run` correctly identifies boot sessions across all agents
- [x] `cleanup_excluded.py` removes sessions, messages, embeddings, and index_log entries
- [x] Watcher skips excluded files (no new boot sessions indexed after restart)
- [x] Activity endpoint returns sessions sorted by last activity
- [x] Long-running sessions appear in "Today" filter when they have recent messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)