### PR TITLE
Switch MCP transport from SSE to Streamable HTTP

### DIFF
--- a/mcp_server_sse.py
+++ b/mcp_server_sse.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-Claw Recall — MCP Server (SSE/HTTP transport)
+Claw Recall — MCP Server (Streamable HTTP transport)
 
-Runs the same MCP server as mcp_server.py but over HTTP (SSE transport)
-instead of stdio. This allows remote agents to connect directly via HTTP.
+Runs the same MCP server as mcp_server.py but over Streamable HTTP transport
+instead of stdio. This is the recommended MCP transport — each tool call is a
+self-contained HTTP request (no persistent SSE session, no initialization race).
 
 Usage:
     python3 mcp_server_sse.py                           # Default: 0.0.0.0:8766
@@ -14,14 +15,15 @@ MCP client config:
     {
       "mcpServers": {
         "claw-recall": {
-          "url": "http://<your-host>:8766/sse"
+          "url": "http://<your-host>:8766/mcp"
         }
       }
     }
 
 Environment variables:
-    MCP_SSE_HOST    Host to bind to (default: 0.0.0.0)
-    MCP_SSE_PORT    Port to bind to (default: 8766)
+    MCP_SSE_HOST        Host to bind to (default: 0.0.0.0)
+    MCP_SSE_PORT        Port to bind to (default: 8766)
+    MCP_SSE_ALLOWED_HOSTS  Extra allowed hosts, comma-separated (e.g. "10.0.0.5:*")
 """
 import os
 import sys
@@ -40,14 +42,19 @@ if __name__ == "__main__":
     mcp.settings.host = host
     mcp.settings.port = port
 
-    # Allow connections from the bound host + common local addresses.
-    # Add more allowed hosts via MCP_SSE_ALLOWED_HOSTS env var (comma-separated).
-    allowed = [f"{host}:*", "127.0.0.1:*", "localhost:*"]
+    # Allow connections from any host when binding to 0.0.0.0 (Tailscale, LAN, etc.)
+    # The server is not exposed to the internet — Tailscale handles access control.
+    if host == "0.0.0.0":
+        allowed = ["*:*"]
+    else:
+        allowed = [f"{host}:*", "127.0.0.1:*", "localhost:*"]
+
     extra = os.environ.get("MCP_SSE_ALLOWED_HOSTS", "")
     if extra:
         allowed.extend(h.strip() for h in extra.split(",") if h.strip())
-    mcp.settings.transport_security.allowed_hosts = allowed
-    mcp.settings.transport_security.allowed_origins = [f"http://{h}" for h in allowed]
 
-    print(f"Claw Recall MCP (SSE) running at http://{host}:{port}/sse")
-    mcp.run(transport="sse")
+    mcp.settings.transport_security.allowed_hosts = allowed
+    mcp.settings.transport_security.allowed_origins = ["*"]
+
+    print(f"Claw Recall MCP (Streamable HTTP) running at http://{host}:{port}/mcp")
+    mcp.run(transport="streamable-http")


### PR DESCRIPTION
## Summary
- Switches from legacy SSE transport to Streamable HTTP (`transport="streamable-http"`)
- Each tool call is a self-contained HTTP POST — eliminates initialization race conditions and stale session crashes
- Endpoint changes from `/sse` to `/mcp`
- Wildcard allowed hosts when binding 0.0.0.0 (Tailscale handles access control)

Fixes #9

## Test plan
- [x] Verified Streamable HTTP server starts and accepts connections
- [x] Verified initialize → notifications/initialized → tools/call flow works
- [x] Verified capture_thought tool call succeeds (thought #27272)
- [ ] CI passes
- [ ] Restart claw-recall-mcp service with new code
- [ ] Update Claude Code MCP client URL from /sse to /mcp
- [ ] Verify CC can call claw-recall tools directly (no more "Invalid request parameters")