### PR TITLE
Add doc freshness tooling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,49 @@
+# Claw Recall — Project Instructions
+
+## Documentation Freshness Rule (MANDATORY)
+
+**Before creating any PR**, check whether your changes affect documentation:
+
+1. If you **renamed, moved, or deleted** any file, module, function, CLI flag, or endpoint:
+   - Search `README.md`, `docs/guide.md`, `CONTRIBUTING.md`, and `CHANGELOG.md` for references
+   - Search the internal reference doc: `~/clawd/reference/claw-recall-reference.md`
+   - Update any stale references in the same PR
+
+2. If you **added** a new feature, endpoint, CLI flag, or MCP tool:
+   - Add it to the appropriate section in `README.md` (if user-facing) or `docs/guide.md` (if operational)
+   - Update the internal reference doc if it covers that area
+
+3. If you **changed behavior** of an existing feature:
+   - Check whether any doc describes the old behavior and update it
+
+**Quick scan command:**
+```bash
+# After making changes, check what docs reference the files you touched:
+git diff --name-only HEAD~1 | xargs -I{} basename {} | xargs -I{} grep -rn {} README.md docs/ CONTRIBUTING.md
+```
+
+## Code Standards
+
+- All modules invoked as `python3 -m claw_recall.xxx`, never as script files
+- Tests: `python3 -m pytest tests/test_claw_recall.py -v`
+- This is a **public repo** — never commit internal IPs, hostnames, paths, API keys, or agent names
+- All changes go through PRs — never push directly to master
+- Version in `VERSION` file — update when releasing
+
+## Package Layout
+
+```
+claw_recall/           # All source code
+  config.py            # Settings (DB_PATH, embedding config, etc.)
+  database.py          # Connection manager
+  cli.py               # CLI entry point
+  search/engine.py     # Search engine
+  search/files.py      # File search
+  capture/thoughts.py  # Thought capture
+  capture/sources.py   # Gmail/Drive/Slack
+  indexing/indexer.py   # Session indexer
+  indexing/watcher.py   # File watcher
+  api/web.py           # Flask REST API
+  api/mcp_stdio.py     # MCP stdio server
+  api/mcp_sse.py       # MCP SSE server
+```

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,14 @@ jobs:
 
       - name: Run tests
         run: PYTHONPATH=. pytest tests/test_claw_recall.py -v --tb=short
+
+  doc-audit:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check docs for stale references
+        run: bash scripts/doc-audit.sh origin/${{ github.base_ref }} HEAD

--- a/scripts/doc-audit.sh
+++ b/scripts/doc-audit.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# doc-audit.sh — Check documentation for references to changed/deleted files
+#
+# Usage:
+#   bash scripts/doc-audit.sh                    # Compare HEAD vs HEAD~1
+#   bash scripts/doc-audit.sh HEAD~5             # Compare HEAD vs 5 commits ago
+#   bash scripts/doc-audit.sh abc1234 def5678    # Compare two specific commits
+#
+# Scans README.md, docs/, CONTRIBUTING.md for references to deleted/renamed
+# source files (*.py, *.sh). Matches code-like references (backtick-wrapped
+# or used as command arguments), not project names or URLs.
+#
+# Exit code 0 = clean, 1 = stale references found.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$SCRIPT_DIR"
+
+# Determine comparison range
+if [ $# -eq 0 ]; then
+    BASE="HEAD~1"
+    HEAD="HEAD"
+elif [ $# -eq 1 ]; then
+    BASE="$1"
+    HEAD="HEAD"
+else
+    BASE="$1"
+    HEAD="$2"
+fi
+
+# Get deleted and renamed files — only source files (.py, .sh)
+TARGETS=""
+while IFS=$'\t' read -r status filepath; do
+    filename=$(basename "$filepath")
+    case "$filename" in
+        *.py|*.sh) TARGETS="$TARGETS $filename" ;;
+    esac
+done < <(git diff --name-status "$BASE" "$HEAD" 2>/dev/null | grep -E '^[DR]' | awk -F'\t' '{print $1"\t"$2}' || true)
+
+TARGETS=$(echo "$TARGETS" | xargs)
+
+if [ -z "$TARGETS" ]; then
+    echo "No deleted/renamed source files (.py/.sh) between $BASE and $HEAD"
+    exit 0
+fi
+
+# Doc files to scan (skip CHANGELOG — historical references are fine)
+DOC_FILES="README.md CONTRIBUTING.md"
+DOC_DIRS="docs/"
+
+FOUND=0
+
+echo "Checking docs for references to deleted/renamed source files..."
+echo "Range: $BASE..$HEAD"
+echo "Files: $TARGETS"
+echo ""
+
+for filename in $TARGETS; do
+    # Build a pattern that matches code-like usage of the exact filename:
+    # - python3 filename.py (not test_filename.py)
+    # - `filename.py` (exact, not as substring)
+    # - path/filename.py (not scripts/filename.py if it still exists)
+    # Exclude matches where the file exists at the referenced path
+    escaped=$(echo "$filename" | sed 's/\./\\./g')
+    pattern="(python3?\s+${escaped}(\s|$)|\`${escaped}\`|[^a-zA-Z_]${escaped}[^a-zA-Z_])"
+
+    scan_doc() {
+        local doc="$1"
+        local raw_matches
+        raw_matches=$(grep -nE "$pattern" "$doc" 2>/dev/null || true)
+        [ -z "$raw_matches" ] && return
+
+        # Filter out lines where filename appears as part of a path that still exists
+        # e.g., "claw_recall/api/web.py" or "scripts/cleanup_excluded.py"
+        local filtered=""
+        while IFS= read -r line; do
+            local content
+            content=$(echo "$line" | cut -d: -f2-)
+            # Skip lines where filename appears as part of a longer path (new location)
+            local path_ref
+            path_ref=$(echo "$content" | grep -oP '\S*'"$filename" | head -1)
+            if [ -n "$path_ref" ] && [ "$path_ref" != "$filename" ]; then
+                if [ -e "$path_ref" ] || echo "$path_ref" | grep -qE 'claw_recall/|scripts/|hooks/|tests/'; then
+                    continue
+                fi
+            fi
+            # Skip indented tree entries (project structure diagrams)
+            if echo "$content" | grep -qE '^\s{2,}'"$filename"'\s'; then
+                continue
+            fi
+            filtered="$filtered$line"$'\n'
+        done <<< "$raw_matches"
+
+        filtered=$(echo "$filtered" | sed '/^$/d')
+        if [ -n "$filtered" ]; then
+            echo "STALE: $doc references deleted '$filename':"
+            echo "$filtered" | sed 's/^/  /'
+            echo ""
+            FOUND=1
+        fi
+    }
+
+    for doc in $DOC_FILES; do
+        [ -f "$doc" ] && scan_doc "$doc"
+    done
+
+    if [ -d "$DOC_DIRS" ]; then
+        while IFS= read -r doc; do
+            scan_doc "$doc"
+        done < <(find "$DOC_DIRS" -name '*.md' -type f 2>/dev/null)
+    fi
+done
+
+if [ "$FOUND" -eq 0 ]; then
+    echo "Clean — no stale doc references found."
+    exit 0
+else
+    echo "---"
+    echo "Found stale references. Update the docs above to fix."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- `.claude/CLAUDE.md` — project-level instructions requiring doc review before every PR
- `scripts/doc-audit.sh` — scans docs for references to deleted/renamed source files
- CI `doc-audit` job on PRs — fails build if stale references found

## How it works
When a PR deletes or renames `.py`/`.sh` files, the CI job scans README.md, CONTRIBUTING.md, and docs/ for references to those filenames. Smart filtering avoids false positives:
- Skips qualified paths that still exist (e.g., `claw_recall/api/web.py` won't match deleted `web.py`)
- Skips indented tree entries in project structure diagrams
- Skips CHANGELOG (historical references are fine)
- Only checks source files, not project names or URLs

## Test plan
- [x] `doc-audit.sh HEAD~3 HEAD` returns clean on current master
- [x] Would have caught the 14 broken README refs from PR #14
- [x] All 123 unit tests pass
- [x] No false positives on current docs

Fixes #17

Generated with [Claude Code](https://claude.com/claude-code)