### PR TITLE
Fix template path resolution in web.py

### DIFF
--- a/claw_recall/api/web.py
+++ b/claw_recall/api/web.py
@@ -61,7 +61,7 @@ def generate_deep_link(content: str) -> str | None:
 
 
 # Templates are in the repo root's templates/ dir
-_REPO_DIR = Path(__file__).resolve().parent.parent
+_REPO_DIR = Path(__file__).resolve().parent.parent.parent
 app = Flask(__name__, template_folder=str(_REPO_DIR / 'templates'))
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB for session files
 


### PR DESCRIPTION
## Summary
- After the v2.1.0 package refactor, `web.py` moved from `claw_recall/web.py` to `claw_recall/api/web.py` (one level deeper)
- `_REPO_DIR` used `.parent.parent` which resolved to `claw_recall/` instead of the repo root
- This caused `TemplateNotFound: index.html` on every request to the web UI
- Fix: `.parent.parent.parent` to correctly resolve to the repo root

## Test plan
- [x] `curl http://172.17.0.1:8765/` returns HTTP 200 after fix
- [x] Web UI loads successfully in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)