### PR TITLE
Fix health check breaking MCP sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,22 +182,27 @@ After saving the file, **restart Claude Code** for the tools to appear. You can 
 
 **Other MCP clients** — any client that supports the MCP stdio transport uses the same JSON structure. Check your client's documentation for where to put MCP server configs.
 
-### Connect a Remote Agent (SSE)
+### Connect a Remote Agent (Streamable HTTP)
 
 Use this when your agent runs on a **different machine** from Claw Recall (e.g., Claw Recall is on a VPS, your agent is on your laptop).
 
-**Step 1:** Start the SSE server on the Claw Recall machine:
+**Step 1:** Start the MCP server on the Claw Recall machine:
 ```bash
 python3 -m claw_recall.api.mcp_sse
 ```
 
 **Step 2:** Connect your agent to it:
 
-**Claude Code:**
-```bash
-claude mcp add --transport sse -s user claw-recall "http://your-server:8766/sse"
-# Replace 'your-server' with the hostname or IP of the machine running Claw Recall
-# Then restart Claude Code
+**Claude Code** — add to `~/.claude.json`:
+```json
+{
+  "mcpServers": {
+    "claw-recall": {
+      "type": "http",
+      "url": "http://your-server:8766/mcp"
+    }
+  }
+}
 ```
 
 **OpenClaw / mcporter / other MCP clients:**
@@ -205,7 +210,7 @@ claude mcp add --transport sse -s user claw-recall "http://your-server:8766/sse"
 {
   "mcpServers": {
     "claw-recall": {
-      "url": "http://your-server:8766/sse"
+      "url": "http://your-server:8766/mcp"
     }
   }
 }
@@ -262,6 +267,54 @@ crontab -e
 # Add this line:
 @reboot cd /home/YOUR_USERNAME/claw-recall && python3 -m claw_recall.api.web --host 127.0.0.1 --port 8765 >> /tmp/claw-recall.log 2>&1
 ```
+
+### Health Monitoring
+
+Claw Recall includes a health check script at `scripts/health-check.sh` that monitors all three services (MCP server, web API, file watcher) and the indexing pipeline. It's designed to run via cron.
+
+**What it checks:**
+1. MCP server is running and responding (uses `/health` endpoint)
+2. Web API is running and search returns results
+3. File watcher service is running
+4. Indexing pipeline is processing new session files
+5. Embedding backfill gap isn't growing
+
+**Setup:**
+```bash
+# Make executable
+chmod +x scripts/health-check.sh
+
+# Add to crontab (runs every 15 min)
+crontab -e
+```
+
+Add this line (adjust paths and URLs for your setup):
+```bash
+*/15 * * * * CLAW_RECALL_MCP_URL=http://127.0.0.1:8766/health \
+  CLAW_RECALL_WEB_URL=http://127.0.0.1:8765/status \
+  CLAW_RECALL_DB=/path/to/convo_memory.db \
+  /bin/bash /path/to/claw-recall/scripts/health-check.sh 2>/dev/null
+```
+
+**Environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAW_RECALL_MCP_URL` | `http://127.0.0.1:8766/health` | MCP server health endpoint |
+| `CLAW_RECALL_WEB_URL` | `http://127.0.0.1:8765/status` | Web API status endpoint |
+| `CLAW_RECALL_DB` | `~/convo_memory.db` | SQLite database path |
+| `CLAW_RECALL_ALERT_SCRIPT` | — | Path to alert script (receives: title, message, priority) |
+| `CLAW_RECALL_LOG` | `/tmp/claw-recall-health.log` | Health check log file |
+| `CLAW_RECALL_SESSION_DIRS` | `~/.openclaw/agents-archive/:...` | Colon-separated session directories |
+| `CLAW_RECALL_EMB_GAP_THRESHOLD` | `400000` | Embedding gap alert threshold |
+
+**Startup grace period:** The MCP server reports `"warming_up"` status for the first 60 seconds after startup while the embedding cache loads. The health check recognizes this and won't trigger false alerts during warmup.
+
+**Alert deduplication:** Same failure pattern only alerts once, then re-alerts every 2 hours if the issue persists. Alerts clear automatically when all checks pass.
+
+**Auto-restart behavior:** If the web API search returns 0 results (stale process), the health check auto-restarts `claw-recall-web`. The MCP server is **not** auto-restarted because that would disconnect all active agent sessions.
+
+Logs are at `/tmp/claw-recall-health.log` (auto-truncated at 2000 lines).
 
 ---
 
@@ -368,7 +421,8 @@ Force a mode with `--keyword` or `--semantic`. Works without an OpenAI key — k
 | MCP tools not appearing | Restart your agent after editing the config. Check the config file path (Claude Code uses `~/.claude.json`). |
 | Search returns nothing | Make sure you indexed first (Step 2). Check with `curl http://127.0.0.1:8765/status` |
 | Semantic search not working | Set `OPENAI_API_KEY` in `.env` and re-index with `--embeddings` |
-| SSE server stops when terminal closes | Use systemd, screen, or `@reboot` cron — see [Keep It Running](#keep-it-running-after-reboot) |
+| MCP server stops when terminal closes | Use systemd, screen, or `@reboot` cron — see [Keep It Running](#keep-it-running-after-reboot) |
+| MCP "Session not found" errors | Check health check logs (`/tmp/claw-recall-health.log`). Likely the server was restarted — see [Health Monitoring](#health-monitoring). |
 
 See the [Full Guide — Troubleshooting](docs/guide.md#troubleshooting) for detailed solutions.
 

--- a/claw_recall/api/mcp_sse.py
+++ b/claw_recall/api/mcp_sse.py
@@ -25,12 +25,40 @@ Environment variables:
     MCP_SSE_PORT        Port to bind to (default: 8766)
     MCP_SSE_ALLOWED_HOSTS  Extra allowed hosts, comma-separated (e.g. "10.0.0.5:*")
 """
+import json
 import os
+import time
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from claw_recall.config import MCP_SSE_HOST, MCP_SSE_PORT
 
 # Import the mcp instance with all tools already registered
 from claw_recall.api.mcp_stdio import mcp
+
+# Track startup time for health check grace period
+_startup_time = time.time()
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    """Health check endpoint for monitoring scripts.
+
+    Returns server status including uptime and readiness state.
+    During the first 60 seconds after startup, reports status as 'warming_up'
+    to prevent health checks from triggering restarts while the embedding
+    cache is being built.
+    """
+    uptime = time.time() - _startup_time
+    warming_up = uptime < 60
+
+    return JSONResponse({
+        "status": "warming_up" if warming_up else "ok",
+        "uptime_seconds": int(uptime),
+        "transport": "streamable-http",
+    })
+
 
 if __name__ == "__main__":
     host = os.environ.get("MCP_SSE_HOST", MCP_SSE_HOST)
@@ -61,4 +89,5 @@ if __name__ == "__main__":
     preload_embedding_cache()
 
     print(f"Claw Recall MCP (Streamable HTTP) running at http://{host}:{port}/mcp")
+    print(f"Health check available at http://{host}:{port}/health")
     mcp.run(transport="streamable-http")

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,21 +1,43 @@
 #!/bin/bash
 # health-check.sh — Claw Recall service health monitoring
-# Runs every 15 min via VPS cron. Alerts via Pushover on failure.
 #
-# Two checks:
-# 1. CRITICAL: MCP SSE server is available and responding to queries
-# 2. IMPORTANT: Indexing pipeline is working (only alerts if there ARE
-#    unindexed session files — won't false-alarm during quiet periods)
+# Monitors MCP server, web API, and indexing pipeline.
+# Designed to run via cron (e.g. every 15 min). Alerts via a configurable
+# script on failure, or logs for manual review if no alert script is set.
+#
+# All configuration is via environment variables — no hardcoded paths or IPs.
+# Set them in your crontab entry or source from a .env file.
+#
+# Required env vars:
+#   CLAW_RECALL_DB             Path to SQLite database
+#
+# Optional env vars:
+#   CLAW_RECALL_MCP_URL        MCP server health endpoint (default: http://127.0.0.1:8766/health)
+#   CLAW_RECALL_WEB_URL        Web API status endpoint (default: http://127.0.0.1:8765/status)
+#   CLAW_RECALL_ALERT_SCRIPT   Path to alert script (receives: title, message, priority)
+#   CLAW_RECALL_LOG            Log file path (default: /tmp/claw-recall-health.log)
+#   CLAW_RECALL_STATE_FILE     State file for alert dedup (default: /tmp/claw-recall-health-state.json)
+#   CLAW_RECALL_EMB_GAP_THRESHOLD  Embedding gap alert threshold (default: 400000)
+#   CLAW_RECALL_SESSION_DIRS   Colon-separated session directories to check for indexing
+#                              (default: ~/.openclaw/agents-archive/:~/.openclaw/agents/:~/.claude/projects/)
+#
+# Example crontab entry:
+#   */15 * * * * CLAW_RECALL_MCP_URL=http://10.0.0.1:8766/health \
+#     CLAW_RECALL_WEB_URL=http://127.0.0.1:8765/status \
+#     CLAW_RECALL_DB=/path/to/convo_memory.db \
+#     /bin/bash /path/to/claw-recall/scripts/health-check.sh 2>/dev/null
 
 set -euo pipefail
 
-# --- Configuration (override via environment or edit below) ---
-PUSHOVER_SCRIPT="${CLAW_RECALL_ALERT_SCRIPT:-}"
-STATE_FILE="/tmp/claw-recall-health-state.json"
-SSE_URL="${CLAW_RECALL_SSE_URL:-http://127.0.0.1:8766/sse}"
+# --- Configuration ---
+MCP_URL="${CLAW_RECALL_MCP_URL:-http://127.0.0.1:8766/health}"
 WEB_URL="${CLAW_RECALL_WEB_URL:-http://127.0.0.1:8765/status}"
 DB_PATH="${CLAW_RECALL_DB:-$HOME/convo_memory.db}"
-LOG="/tmp/claw-recall-health.log"
+ALERT_SCRIPT="${CLAW_RECALL_ALERT_SCRIPT:-}"
+LOG="${CLAW_RECALL_LOG:-/tmp/claw-recall-health.log}"
+STATE_FILE="${CLAW_RECALL_STATE_FILE:-/tmp/claw-recall-health-state.json}"
+EMB_GAP_THRESHOLD="${CLAW_RECALL_EMB_GAP_THRESHOLD:-400000}"
+SESSION_DIRS="${CLAW_RECALL_SESSION_DIRS:-$HOME/.openclaw/agents-archive/:$HOME/.openclaw/agents/:$HOME/.claude/projects/}"
 
 log() { echo "[$(date -u '+%Y-%m-%d %H:%M:%S UTC')] $1" >> "$LOG"; }
 
@@ -26,77 +48,101 @@ fi
 
 FAILURES=""
 
-# ── CHECK 1: MCP SSE server availability (CRITICAL) ──
-# This is what WSL agents connect to. If this is down, agents can't use Recall.
+# ── CHECK 1: MCP server availability (CRITICAL) ──
+# Remote agents connect to this. If it's down, no agent can use Recall.
 
-# 1a. Service running?
-if ! systemctl is-active --quiet claw-recall-mcp.service; then
-    FAILURES="${FAILURES}[CRITICAL] MCP SSE service not running\n"
-    log "FAIL: claw-recall-mcp.service not active"
-else
-    log "OK: claw-recall-mcp.service active"
-fi
-
-# 1b. SSE endpoint actually responds? (GET /sse returns 200 with SSE stream)
-# Note: SSE is streaming so curl always hits max-time (exit 28). That's expected.
-# Use subshell to prevent set -e from killing us on non-zero curl exit.
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 3 "$SSE_URL" 2>/dev/null || true)
-# If curl couldn't connect at all, http_code will be 000
-
-if [ "$HTTP_CODE" != "200" ]; then
-    FAILURES="${FAILURES}[CRITICAL] MCP SSE endpoint returned HTTP $HTTP_CODE (expected 200)\n"
-    log "FAIL: SSE endpoint HTTP $HTTP_CODE"
-else
-    log "OK: SSE endpoint HTTP 200"
-fi
-
-# 1c. Web API responds? (needed for /recent, /search, session viewer)
-if ! systemctl is-active --quiet claw-recall-web.service; then
-    FAILURES="${FAILURES}[CRITICAL] Web API service not running\n"
-    log "FAIL: claw-recall-web.service not active"
-else
-    STATUS_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "$WEB_URL" 2>/dev/null || echo "000")
-    if [ "$STATUS_CODE" != "200" ]; then
-        FAILURES="${FAILURES}[CRITICAL] Web API /status returned HTTP $STATUS_CODE\n"
-        log "FAIL: Web API HTTP $STATUS_CODE"
+# 1a. Service running? (skip if systemctl not available — e.g. Docker, macOS)
+if command -v systemctl &>/dev/null; then
+    if ! systemctl is-active --quiet claw-recall-mcp.service 2>/dev/null; then
+        FAILURES="${FAILURES}[CRITICAL] MCP service not running\n"
+        log "FAIL: claw-recall-mcp.service not active"
     else
-        log "OK: Web API HTTP 200"
+        log "OK: claw-recall-mcp.service active"
     fi
+fi
 
-    # 1d. Search actually returns results? (catches stale-process bugs)
-    # Use a common word that should always have hits in 1.1M+ messages.
-    SEARCH_URL="${WEB_URL%/status}/search?q=order&limit=1&force_keyword=true"
+# 1b. MCP /health endpoint responds?
+# The /health endpoint returns JSON with status and uptime. During the first
+# 60 seconds after startup it returns {"status": "warming_up"} — this is
+# normal (embedding cache building) and should NOT trigger a restart.
+MCP_RESPONSE=$(curl -sf --connect-timeout 5 --max-time 5 "$MCP_URL" 2>/dev/null || echo '{}')
+MCP_STATUS=$(echo "$MCP_RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+
+if [ -z "$MCP_STATUS" ]; then
+    # No response at all — server is down
+    FAILURES="${FAILURES}[CRITICAL] MCP server not responding at $MCP_URL\n"
+    log "FAIL: MCP /health not responding"
+elif [ "$MCP_STATUS" = "warming_up" ]; then
+    # Server just started, embedding cache is building — this is expected
+    log "OK: MCP server warming up (embedding cache building)"
+elif [ "$MCP_STATUS" = "ok" ]; then
+    log "OK: MCP server healthy"
+else
+    FAILURES="${FAILURES}[CRITICAL] MCP server returned unexpected status: $MCP_STATUS\n"
+    log "FAIL: MCP /health returned status=$MCP_STATUS"
+fi
+
+# ── CHECK 2: Web API availability (CRITICAL) ──
+# Needed for /recent, /search, session viewer.
+
+if command -v systemctl &>/dev/null; then
+    if ! systemctl is-active --quiet claw-recall-web.service 2>/dev/null; then
+        FAILURES="${FAILURES}[CRITICAL] Web API service not running\n"
+        log "FAIL: claw-recall-web.service not active"
+    else
+        log "OK: claw-recall-web.service active"
+    fi
+fi
+
+STATUS_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "$WEB_URL" 2>/dev/null || echo "000")
+if [ "$STATUS_CODE" != "200" ]; then
+    FAILURES="${FAILURES}[CRITICAL] Web API returned HTTP $STATUS_CODE\n"
+    log "FAIL: Web API HTTP $STATUS_CODE"
+else
+    log "OK: Web API HTTP 200"
+
+    # 2b. Search actually returns results? (catches stale-process bugs)
+    SEARCH_URL="${WEB_URL%/status}/search?q=the&limit=1&force_keyword=true"
     SEARCH_RESULT=$(curl -sf --connect-timeout 5 --max-time 15 "$SEARCH_URL" 2>/dev/null || echo '{"conversations":[]}')
     CONVO_COUNT=$(echo "$SEARCH_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('conversations',[])))" 2>/dev/null || echo "0")
     if [ "$CONVO_COUNT" -eq 0 ]; then
         FAILURES="${FAILURES}[CRITICAL] Search returns 0 results — service may need restart\n"
         log "FAIL: Search returned 0 results (stale process?)"
-        # Auto-restart both services to recover (MCP has the same stale-process risk)
-        sudo systemctl restart claw-recall-web claw-recall-mcp 2>/dev/null
-        log "AUTO-RESTART: claw-recall-web + claw-recall-mcp restarted"
+        # Auto-restart only the web service (not MCP — that kills agent sessions)
+        if command -v systemctl &>/dev/null; then
+            sudo systemctl restart claw-recall-web 2>/dev/null
+            log "AUTO-RESTART: claw-recall-web restarted"
+        fi
     else
         log "OK: Search returning results ($CONVO_COUNT)"
     fi
 fi
 
-# ── CHECK 2: Indexing pipeline health (IMPORTANT) ──
+# ── CHECK 3: Indexing pipeline health (IMPORTANT) ──
 # Only alert if there are session files that SHOULD have been indexed but weren't.
-# Won't false-alarm during quiet periods when nobody's talking.
 
-# 2a. Watcher service running?
-if ! systemctl is-active --quiet claw-recall-watcher.service; then
-    FAILURES="${FAILURES}[WARN] Watcher service not running — new sessions won't be indexed\n"
-    log "FAIL: claw-recall-watcher.service not active"
-else
-    log "OK: claw-recall-watcher.service active"
+if command -v systemctl &>/dev/null; then
+    if ! systemctl is-active --quiet claw-recall-watcher.service 2>/dev/null; then
+        FAILURES="${FAILURES}[WARN] Watcher service not running — new sessions won't be indexed\n"
+        log "FAIL: claw-recall-watcher.service not active"
+    else
+        log "OK: claw-recall-watcher.service active"
+    fi
 fi
 
-# 2b. Check if there are recently modified .jsonl files that haven't been indexed.
-# Find session files modified in last 2 hours, then check if the most recent
-# index_log entry is older than 2 hours. If so, indexing may be stuck.
 if [ -f "$DB_PATH" ]; then
-    RECENT_INDEX=$(sqlite3 "$DB_PATH" "SELECT MAX(indexed_at) FROM index_log WHERE indexed_at > datetime('now', '-2 hours')" 2>/dev/null)
-    RECENT_SESSION_FILES=$(find ~/.openclaw/agents-archive/ ~/.openclaw/agents/ ~/.claude/projects/ -name "*.jsonl" -mmin -120 2>/dev/null | wc -l)
+    RECENT_INDEX=$(sqlite3 "$DB_PATH" "SELECT MAX(indexed_at) FROM index_log WHERE indexed_at > datetime('now', '-2 hours')" 2>/dev/null || echo "")
+
+    # Count recently modified session files across configured directories
+    RECENT_SESSION_FILES=0
+    IFS=':' read -ra DIRS <<< "$SESSION_DIRS"
+    for dir in "${DIRS[@]}"; do
+        expanded_dir=$(eval echo "$dir")
+        if [ -d "$expanded_dir" ]; then
+            count=$(find "$expanded_dir" -name "*.jsonl" -mmin -120 2>/dev/null | wc -l)
+            RECENT_SESSION_FILES=$((RECENT_SESSION_FILES + count))
+        fi
+    done
 
     if [ "$RECENT_SESSION_FILES" -gt 0 ] && [ -z "$RECENT_INDEX" ]; then
         FAILURES="${FAILURES}[WARN] $RECENT_SESSION_FILES session files modified in last 2h but no indexing activity\n"
@@ -105,11 +151,8 @@ if [ -f "$DB_PATH" ]; then
         log "OK: Indexing pipeline healthy (files=$RECENT_SESSION_FILES, recent_index=${RECENT_INDEX:-none})"
     fi
 
-    # 2c. Check embedding gap — alert if growing significantly
+    # Check embedding gap
     EMB_GAP=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM messages m LEFT JOIN embeddings e ON e.message_id = m.id WHERE e.id IS NULL AND LENGTH(m.content) >= 50" 2>/dev/null || echo "0")
-    # Alert threshold — set higher during initial backfill, lower once caught up.
-    # The backfill_embeddings.py cron processes ~500/run; a growing gap means it broke.
-    EMB_GAP_THRESHOLD="${CLAW_RECALL_EMB_GAP_THRESHOLD:-400000}"
     if [ "$EMB_GAP" -gt "$EMB_GAP_THRESHOLD" ]; then
         FAILURES="${FAILURES}[WARN] Embedding gap: $EMB_GAP messages without embeddings\n"
         log "WARN: Embedding gap $EMB_GAP"
@@ -129,21 +172,18 @@ if [ -n "$FAILURES" ]; then
     fi
 
     NOW=$(date +%s)
-    # Alert on new failure, or re-alert every 2 hours for persistent failures
     SINCE_LAST=$((NOW - LAST_TIME))
+    # Alert on new failure, or re-alert every 2 hours for persistent failures
     if [ "$FAILURE_HASH" != "$LAST_HASH" ] || [ "$SINCE_LAST" -gt 7200 ]; then
         log "ALERT: Sending notification"
         ALERT_MSG=$(echo -e "$FAILURES")
-        # Send alert via configured script (receives: title, message, priority)
-        # Priority: 1 = CRITICAL, 0 = WARN
-        if [ -n "$PUSHOVER_SCRIPT" ] && [ -f "$PUSHOVER_SCRIPT" ]; then
+        if [ -n "$ALERT_SCRIPT" ] && [ -f "$ALERT_SCRIPT" ]; then
             PRIORITY=0
             if echo -e "$FAILURES" | grep -q "CRITICAL"; then
                 PRIORITY=1
             fi
-            bash "$PUSHOVER_SCRIPT" "Claw Recall Alert" "$ALERT_MSG" "$PRIORITY" 2>/dev/null || true
+            bash "$ALERT_SCRIPT" "Claw Recall Alert" "$ALERT_MSG" "$PRIORITY" 2>/dev/null || true
         else
-            # No alert script configured — log the alert for manual review
             log "ALERT (no alert script configured): $ALERT_MSG"
         fi
         python3 -c "import json,sys; json.dump({'hash':sys.argv[1],'epoch':int(sys.argv[2]),'time':sys.argv[3]},open(sys.argv[4],'w'))" "$FAILURE_HASH" "$NOW" "$(date -u -Iseconds)" "$STATE_FILE"
@@ -151,7 +191,6 @@ if [ -n "$FAILURES" ]; then
         log "SUPPRESSED: Same failure, last alert ${SINCE_LAST}s ago"
     fi
 else
-    # Clear state on success
     if [ -f "$STATE_FILE" ]; then
         rm "$STATE_FILE"
         log "RECOVERED: All checks passed — cleared failure state"


### PR DESCRIPTION
## Summary

Fixes #28 — Health check was restarting the MCP server every 15 minutes, breaking all active client sessions.

**Root cause:** Two issues compounding:
1. Health check probed `GET /sse` which returns 404 since the server migrated to Streamable HTTP transport (endpoint is now `/mcp`)
2. During embedding cache warmup (~60s after restart), keyword search returns 0 results, triggering an auto-restart — creating a restart loop

**Changes:**
- Add `/health` endpoint to MCP server with 60-second startup grace period (reports `"warming_up"` while embedding cache loads)
- Rewrite `scripts/health-check.sh` to use `/health` instead of `/sse`
- Health check no longer auto-restarts MCP server — only restarts `claw-recall-web` when search is broken
- All configuration via environment variables (no hardcoded paths or IPs)
- Update README: SSE → Streamable HTTP references, new Health Monitoring section, troubleshooting entry

## Test plan

- [ ] Verify `python3 -m pytest tests/ -x` passes (144 tests pass)
- [ ] Restart MCP server, verify `/health` returns `{"status": "warming_up"}` for first 60s
- [ ] After 60s, verify `/health` returns `{"status": "ok"}`
- [ ] Run `scripts/health-check.sh` manually — should report all OK
- [ ] Update cron entry to use `CLAW_RECALL_MCP_URL` instead of `CLAW_RECALL_SSE_URL`
- [ ] Monitor health check logs for 1 hour — no false restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)