### PR TITLE
Enable stateless HTTP + fix health check search word

### DIFF
--- a/claw_recall/api/mcp_sse.py
+++ b/claw_recall/api/mcp_sse.py
@@ -82,6 +82,11 @@ if __name__ == "__main__":
     mcp.settings.transport_security.allowed_hosts = allowed
     mcp.settings.transport_security.allowed_origins = ["*"]
 
+    # Stateless mode: each request is self-contained (no session tracking).
+    # This prevents "Session not found" errors when the server restarts —
+    # clients don't need to re-initialize after a restart or deployment.
+    mcp.settings.stateless_http = True
+
     # Preload embedding cache in background to avoid cold-start latency.
     # Without this, the first semantic search after startup (or after 4h idle)
     # takes ~100s to rebuild the cache, during which searches return empty.

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -102,9 +102,12 @@ else
     log "OK: Web API HTTP 200"
 
     # 2b. Search actually returns results? (catches stale-process bugs)
-    SEARCH_URL="${WEB_URL%/status}/search?q=the&limit=1&force_keyword=true"
-    SEARCH_RESULT=$(curl -sf --connect-timeout 5 --max-time 15 "$SEARCH_URL" 2>/dev/null || echo '{"conversations":[]}')
-    CONVO_COUNT=$(echo "$SEARCH_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('conversations',[])))" 2>/dev/null || echo "0")
+    # Use a common non-stopword that should always have hits. "the" is an FTS5
+    # stop word and returns 0 results for keyword search.
+    SEARCH_URL="${WEB_URL%/status}/search?q=error&limit=1&force_keyword=true"
+    SEARCH_RESULT=$(curl -sf --connect-timeout 5 --max-time 15 "$SEARCH_URL" 2>/dev/null || echo '{"conversations":[],"files":[]}')
+    # Count both conversations and files — either having results means search works
+    CONVO_COUNT=$(echo "$SEARCH_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('conversations',[]))+len(d.get('files',[])))" 2>/dev/null || echo "0")
     if [ "$CONVO_COUNT" -eq 0 ]; then
         FAILURES="${FAILURES}[CRITICAL] Search returns 0 results — service may need restart\n"
         log "FAIL: Search returned 0 results (stale process?)"


### PR DESCRIPTION
## Summary

Follow-up to #28 — two issues found during post-merge testing:

1. **Stateless HTTP mode**: MCP server was still running stateful sessions. After any restart, clients got "Session not found" because cached session IDs were invalidated. Now uses `stateless_http=True` — each request is self-contained, no stale sessions.

2. **Health check search word**: Used "the" which is an FTS5 stop word — returns 0 results for keyword search, triggering unnecessary web API restarts every 15 min. Changed to "error" and now counts both conversations + files as valid results.

## Test plan

- [x] MCP keyword search works from WSL via Tailscale (6.9s)
- [x] MCP semantic search works from WSL via Tailscale (6.6s)
- [x] MCP browse_recent works from WSL via Tailscale (7.1s)
- [x] VPS CLI keyword search works (1.8s)
- [x] VPS CLI semantic search works (4.4s)
- [x] /health endpoint returns correct status
- [ ] Health check script passes with "error" search word
- [ ] No false restarts in health check logs for 1 hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)