### PR TITLE
fix(ci): add mcp dep and handle missing OPENAI_API_KEY

### DIFF
--- a/claw_recall/capture/thoughts.py
+++ b/claw_recall/capture/thoughts.py
@@ -32,6 +32,9 @@ def _get_openai_client() -> Optional['OpenAI']:
     global _openai_client
     if not OPENAI_AVAILABLE:
         return None
+    import os
+    if not os.environ.get('OPENAI_API_KEY'):
+        return None
     if _openai_client is None:
         _openai_client = OpenAI()
     return _openai_client

--- a/claw_recall/capture/thoughts.py
+++ b/claw_recall/capture/thoughts.py
@@ -32,11 +32,13 @@ def _get_openai_client() -> Optional['OpenAI']:
     global _openai_client
     if not OPENAI_AVAILABLE:
         return None
+    # Return existing client if already set (e.g. by tests via monkeypatch)
+    if _openai_client is not None:
+        return _openai_client
     import os
     if not os.environ.get('OPENAI_API_KEY'):
         return None
-    if _openai_client is None:
-        _openai_client = OpenAI()
+    _openai_client = OpenAI()
     return _openai_client
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,9 @@ numpy>=1.24.0
 # For semantic search (optional)
 openai>=1.0.0
 
+# For MCP server
+mcp>=1.0.0
+
 # For web interface (optional)
 flask>=2.0.0
 


### PR DESCRIPTION
## Summary

- Add `mcp>=1.0.0` to `requirements.txt` — `ci.yml` installs from this file but `mcp` was missing, causing `ModuleNotFoundError` in `TestMCPServer` and `TestBrowseRecent` (5 failures)
- Guard `_get_openai_client()` against missing `OPENAI_API_KEY` — `OpenAI()` raises at instantiation when the env var is absent, so `test_batch_embed_empty` errored before reaching the "no rows" return path (1 failure)

## Test plan

- [ ] CI passes on this PR (all 6 previously-failing tests now pass)
- [ ] `144 passed` locally confirmed with `OPENAI_API_KEY=""` to simulate CI environment